### PR TITLE
Update help.js - replace deprecated functions

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -26,7 +26,7 @@ function renderComponent() {
  **/
 function simulateEvent(element, event) {
     TestUtils.Simulate[event](
-       element.getDOMNode ? element.getDOMNode() : element
+       React.findDOMNode(element) ? React.findDOMNode(element) : element
     );
 }
 
@@ -39,7 +39,7 @@ function simulateEvent(element, event) {
  **/
 function simulateNativeEvent(element, event) {
     TestUtils.SimulateNative[event](
-       element.getDOMNode ? element.getDOMNode() : element
+       React.findDOMNode(element) ? React.findDOMNode(element) : element
     );
 }
 
@@ -52,7 +52,7 @@ function simulateNativeEvent(element, event) {
  * @return {DOMNode} the first DOM node that matches the query
  **/
 function elementQuerySelector(element, query) {
-    return element.getDOMNode().querySelector(query);
+    return React.findDOMNode(element).querySelector(query);
 }
 
 /**
@@ -64,7 +64,7 @@ function elementQuerySelector(element, query) {
  * @return {DOMNode} all DOM nodes that matches the query
  **/
 function elementQuerySelectorAll(element, query) {
-    return element.getDOMNode().querySelectorAll(query);
+    return React.findDOMNode(element).querySelectorAll(query);
 }
 
 /**

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -26,7 +26,7 @@ function renderComponent() {
  **/
 function simulateEvent(element, event) {
     TestUtils.Simulate[event](
-       React.findDOMNode(element) ? React.findDOMNode(element) : element
+       React.findDOMNode(element) || element
     );
 }
 
@@ -39,7 +39,7 @@ function simulateEvent(element, event) {
  **/
 function simulateNativeEvent(element, event) {
     TestUtils.SimulateNative[event](
-       React.findDOMNode(element) ? React.findDOMNode(element) : element
+       React.findDOMNode(element) || element
     );
 }
 


### PR DESCRIPTION
Replacement of deprecated function getDOMNode by findDOMNode. Supporting ES6 based components (babel transformed or some other..) testing.

You can reproduce the problem with this replic of your example component and test in ES6:
ES6 Component(use babel transform or some other): http://pastebin.com/dTsSyxYt
Test: http://pastebin.com/3KcAU4ab