### PR TITLE
fix warnings

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -79,18 +79,20 @@ function stubComponent(tag, children, showDataProps) {
     return React.createClass({
         displayName: tag.displayName || tag,
 
-        componentWillMount: function () {
-            showDataProps && this.addDataProps();
-        },
+        getStubProps: function () {
+            var props = this.props;
 
-        addDataProps: function () {
-            Object.keys(this.props).forEach(function (key) {
-                this.props['data-' + key] = this.props[key]
-            }, this);
+            return Object.keys(props).reduce(function (clonedProps, key) {
+                clonedProps[key] = props[key];
+                if (showDataProps) {
+                    clonedProps['data-' + key.toLowerCase()] = props[key];
+                }
+                return clonedProps;
+            }, {});
         },
 
         render: function () {
-            return React.createElement(tag, this.props, children);
+            return React.createElement(tag, this.getStubProps(), children);
         }
     });
 }


### PR DESCRIPTION
@3den  Couple of warnings I got:

- `Warning: Unknown DOM property data-className. Did you mean data-classname?` so we'll have to lower-case the keys.

- `Warning: Don't set .props.data-className of the React component <div />. Instead, specify the correct value when initially creating the element or use React.cloneElement to make a new element with updated props. The element was created by ...` We can't modify `this.props` so we'll have to clone it.