### PR TITLE
Prefer using babel instead of react-tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,15 @@
 
 The main features of `jsx-test` are:
 
-* Allows you to require `.jsx` files directly in your test.
 * Includes some helpers to simplify the test of React Components.
 * Assertion methods to check the component renders the correct html based on the given `props`.
 * Does NOT automock your dependencies.
 * Is much simpler and faster than Jest.
 * Works with `mocha`, `jasmine` or any other test framework.
 
-## Install
+*Note:* If you would like to require jsx files directly please follow [these instructions](https://babeljs.io/docs/setup/)
+
+## Instal
 
 ```
 npm install --save-dev jsx-test

--- a/index.js
+++ b/index.js
@@ -14,19 +14,10 @@ global.Event = window.Event;
 
 // Require other dependencies
 var fs = require('fs');
-var ReactTools = require('react-tools');
 
 // Require libs
 var assert = require('./lib/assert');
 var helper = require('./lib/helper');
-
-// Allows requirea to load `.jsx` files directly
-require.extensions['.jsx'] = function(module, filename) {
-    var content;
-    content = fs.readFileSync(filename, 'utf8');
-    var compiled = ReactTools.transform(content, {harmony: true});
-    return module._compile(compiled, filename);
-};
 
 /**
  * Allow `jsx` files to be required.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "An easy way to test your React Components (`.jsx` files).",
   "main": "index.js",
   "scripts": {
-    "test": "mocha example/**/*.test.js test/**/*.test.js"
+    "test": "mocha --compilers js:babel/register example/**/*.test.js test/**/*.test.js"
   },
   "repository": {
     "type": "git",
@@ -22,11 +22,11 @@
   },
   "homepage": "https://github.com/yahoo/jsx-test",
   "devDependencies": {
+    "babel": "^5.0.0",
     "mocha": "^2.1.0"
   },
   "dependencies": {
     "jsdom": "^3.0.0",
-    "react": "^0.13.0",
-    "react-tools": "^0.13.0"
+    "react": "^0.13.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsx-test",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "An easy way to test your React Components (`.jsx` files).",
   "main": "index.js",
   "scripts": {

--- a/test/withContext.test.js
+++ b/test/withContext.test.js
@@ -57,6 +57,6 @@ describe('#withContext', function() {
             render: function () {return null;}
         });
 
-        assert.equal(jsx.withContext(UnnamedComponent, {}).displayName, 'Component:withContext');
+        assert.equal(jsx.withContext(UnnamedComponent, {}).displayName, 'UnnamedComponent:withContext');
     });
 });


### PR DESCRIPTION
@ZeikJT @3den React is in the process of [deprecating react-tools](https://github.com/facebook/react/issues/3743). This PR removes react-tools being used from jsx-test and instead prefers using babel which gives the same build step that we did via a command line flag or library for anybody to use. This removes the "magic" piece to require jsx files but does allow the flexibility to people to use custom compilers to require files. My personal motivation for this is I need to run a compiler that instruments the code using istanbul when I require jsx files instead of using react-tools or the babel compiler directly