### PR TITLE
require JSX files that can be covered by istanbul.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ lib-cov
 
 # Coverage directory used by tools like istanbul
 coverage
+artifacts
 
 # Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
 .grunt

--- a/example/UnnamedComponent.jsx
+++ b/example/UnnamedComponent.jsx
@@ -1,0 +1,9 @@
+var React = require('react');
+
+var UnnamedComponent = React.createClass({
+    render: function() {
+        return <div>UNNAMED_COMPONENT</div>;
+    }
+});
+
+module.exports = UnnamedComponent;

--- a/example/test/CheckboxWithLabel.test.js
+++ b/example/test/CheckboxWithLabel.test.js
@@ -1,5 +1,5 @@
 // jsx-test
-var jsx = require('../../index').jsxTranspile();
+var jsx = require('../../index').jsxTranspile(process.env.COVERAGE);
 var assert = require('assert');
 
 describe('CheckboxWithLabel', function() {

--- a/example/test/UnnamedComponent.test.js
+++ b/example/test/UnnamedComponent.test.js
@@ -1,0 +1,13 @@
+// jsx-test
+var jsx = require('../../index').jsxTranspile();
+var assert = require('assert');
+
+describe('UnnamedComponent', function() {
+    var UnnamedComponent = require('../UnnamedComponent.jsx');
+
+    describe('#render', function () {
+        it('renders with <div>UNNAMED_COMPONENT</div>', function () {
+            jsx.assertRender(UnnamedComponent, {}, '<div>UNNAMED_COMPONENT</div>');
+        });
+    });
+});

--- a/example/test/UnnamedComponent.test.js
+++ b/example/test/UnnamedComponent.test.js
@@ -1,5 +1,5 @@
 // jsx-test
-var jsx = require('../../index').jsxTranspile();
+var jsx = require('../../index').jsxTranspile(process.env.COVERAGE);
 var assert = require('assert');
 
 describe('UnnamedComponent', function() {

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -146,7 +146,6 @@ function jsxTranspile(instrument) {
     var babel = require('babel');
 
     if (instrument !== undefined && instrument && instrument === 'true') {
-console.log('instrument');
         var istanbul = require('istanbul');
         var coverageVariable = Object.keys(global).filter(
             function (key) {
@@ -163,7 +162,6 @@ console.log('instrument');
         };
     }
     else {
-console.log('normal');
         require.extensions['.jsx'] = function (module, filename) {
             var content = fs.readFileSync(filename, 'utf8');
             var compiled = babel.transform(content, {nonStandard: true});

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -139,25 +139,37 @@ function withContext(Component, context) {
  * this method is not needed if you are using babel
  *
  * @method jsxTranspile
+ * @param {Boolean} instrument the original code
  **/
-function jsxTranspile() {
+function jsxTranspile(instrument) {
     var fs = require('fs');
     var babel = require('babel');
-    var istanbul = require('istanbul');
-    var coverageVariable = Object.keys(global).filter(
-        function (key) {
-            return /^\$\$cov_/.test(key);
-        })[0];
-    var instrumenter = new istanbul.Instrumenter({
-            coverageVariable: coverageVariable
-        });
 
-    require.extensions['.jsx'] = function (module, filename) {
-        var content = fs.readFileSync(filename, 'utf8');
-        var compiled = babel.transform(content, {nonStandard: true});
-        var instrumented = instrumenter.instrumentSync(compiled.code, filename);
-        return module._compile(instrumented, filename);
-    };
+    if (instrument !== undefined && instrument && instrument === 'true') {
+console.log('instrument');
+        var istanbul = require('istanbul');
+        var coverageVariable = Object.keys(global).filter(
+            function (key) {
+                return /^\$\$cov_/.test(key);
+            })[0];
+        var instrumenter = new istanbul.Instrumenter({
+                coverageVariable: coverageVariable
+            });
+        require.extensions['.jsx'] = function (module, filename) {
+            var content = fs.readFileSync(filename, 'utf8');
+            var compiled = babel.transform(content, {nonStandard: true});
+            var instrumented = instrumenter.instrumentSync(compiled.code, filename);
+            return module._compile(instrumented, filename);
+        };
+    }
+    else {
+console.log('normal');
+        require.extensions['.jsx'] = function (module, filename) {
+            var content = fs.readFileSync(filename, 'utf8');
+            var compiled = babel.transform(content, {nonStandard: true});
+            return module._compile(compiled.code, filename);
+        };
+    }
 
     return this;
 }

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -143,11 +143,20 @@ function withContext(Component, context) {
 function jsxTranspile() {
     var fs = require('fs');
     var babel = require('babel');
+    var istanbul = require('istanbul');
+    var coverageVariable = Object.keys(global).filter(
+        function (key) {
+            return /^\$\$cov_/.test(key);
+        })[0];
+    var instrumenter = new istanbul.Instrumenter({
+            coverageVariable: coverageVariable
+        });
 
     require.extensions['.jsx'] = function (module, filename) {
         var content = fs.readFileSync(filename, 'utf8');
         var compiled = babel.transform(content, {nonStandard: true});
-        return module._compile(compiled.code, filename);
+        var instrumented = instrumenter.instrumentSync(compiled.code, filename);
+        return module._compile(instrumented, filename);
     };
 
     return this;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "An easy way to test your React Components (`.jsx` files).",
   "main": "index.js",
   "scripts": {
-    "test": "mocha --compilers js:babel/register example/**/*.test.js test/**/*.test.js"
+    "cover": "jenkins-mocha example/**/*.test.js test/**/*.test.js",
+    "test": "jenkins-mocha --no-coverage example/**/*.test.js test/**/*.test.js"
   },
   "repository": {
     "type": "git",
@@ -23,7 +24,8 @@
   "homepage": "https://github.com/yahoo/jsx-test",
   "devDependencies": {
     "babel": "^5.0.0",
-    "mocha": "^2.1.0"
+    "istanbul": "^0.3.15",
+    "jenkins-mocha": "^2.2.0"
   },
   "dependencies": {
     "jsdom": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "An easy way to test your React Components (`.jsx` files).",
   "main": "index.js",
   "scripts": {
-    "cover": "jenkins-mocha example/**/*.test.js test/**/*.test.js",
+    "cover": "COVERAGE=true jenkins-mocha example/**/*.test.js test/**/*.test.js",
     "test": "jenkins-mocha --no-coverage example/**/*.test.js test/**/*.test.js"
   },
   "repository": {

--- a/test/withContext.test.js
+++ b/test/withContext.test.js
@@ -32,7 +32,7 @@ describe('#withContext', function() {
 
         jsx.assertRender(jsx.withContext(ContextUser, {}), {str: 'Awesome String!'}, '<span>Awesome String!</span>');
     });
-    
+
     it('allows calling methods from underlying component', function () {
         var UnderlyingComponent = React.createClass({
             underlyingMethod: function (n1, n2) {
@@ -53,10 +53,7 @@ describe('#withContext', function() {
     });
 
     it('creates a readable displayName even if Component did not have one', function () {
-        var UnnamedComponent = React.createClass({
-            render: function () {return null;}
-        });
-
+        var UnnamedComponent = require('../example/UnnamedComponent.jsx');
         assert.equal(jsx.withContext(UnnamedComponent, {}).displayName, 'UnnamedComponent:withContext');
     });
 });


### PR DESCRIPTION
@akshayp 

I am using `jsx-test` to test my react components and I would like to instrument the "transpiled" `.jsx` files and show up in the coverage report.  This PR:

- update the `jsxTranspile` method to support `.jsx` file instrumentation using [istabual](1).
- update npm run-script targets using [jenkin-mocha](2).

**1. The Walkthrough**
![jsx-test](https://cloud.githubusercontent.com/assets/51471/8266523/4343d37a-16e7-11e5-8ed8-f9ac3d420e0e.gif)

**2. Report for JSX file**
![screen shot 2015-06-20 at 12 51 32 am](https://cloud.githubusercontent.com/assets/51471/8266528/6d95cb42-16e7-11e5-98fd-78fb045aa5e1.png)

**3. Test with Coverage Result**
```bash
➜  jsx-test git:(instrumented-jsx-files) npm run cover

> jsx-test@0.6.3 cover /Users/stanleyn/Projects/public/git/yahoo/jsx-test
> jenkins-mocha example/**/*.test.js test/**/*.test.js



  CheckboxWithLabel
    ✓ changes the text after click
    ✓ triggers native events
    #render
      ✓ renders with a custom label OFF
      ✓ does not render a the unchecked label
      ✓ renders with a custom label ON
      ✓ renders with a checkbox field

  UnnamedComponent
    #render
      ✓ renders with <div>UNNAMED_COMPONENT</div>

  #assertRender
    ✓ renders the exact HTML
    ✓ renders the attomic classes HTML
    ✓ should handle data-react-* truncation correctly
    ✓ includes some expecific content on the rendered HTML
    ✓ matches a regex on the rendered HTML

  #renderComponent
    ✓ renders props & children on the component

  #stubComponent
    ✓ renders props on the component
    ✓ renders children content the component
    ✓ adds all props to data props

  #withContext
    ✓ gives child context
    ✓ passes props through context wrapper to child
    ✓ allows calling methods from underlying component
    ✓ creates a readable displayName using Component.displayName
    ✓ creates a readable displayName even if Component did not have one


  21 passing (82ms)

=============================================================================
Writing coverage object [/Users/stanleyn/Projects/public/git/yahoo/jsx-test/artifacts/coverage/coverage.json]
Writing coverage reports at [/Users/stanleyn/Projects/public/git/yahoo/jsx-test/artifacts/coverage]
=============================================================================

=============================== Coverage summary ===============================
Statements   : 96.81% ( 91/94 )
Branches     : 83.33% ( 15/18 )
Functions    : 93.33% ( 28/30 )
Lines        : 96.81% ( 91/94 )
================================================================================
```

**4. Test without Coverage Result**
```bash
➜  jsx-test git:(instrumented-jsx-files) npm run  test

> jsx-test@0.6.3 test /Users/stanleyn/Projects/public/git/yahoo/jsx-test
> jenkins-mocha --no-coverage example/**/*.test.js test/**/*.test.js



  CheckboxWithLabel
    ✓ changes the text after click
    ✓ triggers native events
    #render
      ✓ renders with a custom label OFF
      ✓ does not render a the unchecked label
      ✓ renders with a custom label ON
      ✓ renders with a checkbox field

  UnnamedComponent
    #render
      ✓ renders with <div>UNNAMED_COMPONENT</div>

  #assertRender
    ✓ renders the exact HTML
    ✓ renders the attomic classes HTML
    ✓ should handle data-react-* truncation correctly
    ✓ includes some expecific content on the rendered HTML
    ✓ matches a regex on the rendered HTML

  #renderComponent
    ✓ renders props & children on the component

  #stubComponent
    ✓ renders props on the component
    ✓ renders children content the component
    ✓ adds all props to data props

  #withContext
    ✓ gives child context
    ✓ passes props through context wrapper to child
    ✓ allows calling methods from underlying component
    ✓ creates a readable displayName using Component.displayName
    ✓ creates a readable displayName even if Component did not have one


  21 passing (78ms)
```

[1]: https://github.com/gotwarlost/istanbul
[2]: https://github.com/stjohnjohnson/jenkins-mocha
