### PR TITLE
jsxTranspile changes

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -145,41 +145,28 @@ function jsxTranspile(instrument) {
     var fs = require('fs');
     var babel = require('babel');
 
-    if (instrument && instrument === 'true') {
-        var istanbul = require('istanbul');
-        var coverageVariable = Object.keys(global).filter(
-            function (key) {
-                return /^\$\$cov_/.test(key);
-            })[0];
-        var instrumenter = new istanbul.Instrumenter({
-                coverageVariable: coverageVariable
-            });
-        var content;
-        var compiled;
+    require.extensions['.jsx'] = function (module, filename) {
+        var content = fs.readFileSync(filename, 'utf8');
+        var compiled = babel.transform(content, {nonStandard: true, retainLines: true});
 
-        require.extensions['.jsx'] = function (module, filename) {
-            if (/(tests|node_modules)/.test(filename)) {
-                // No instrument
-                content = fs.readFileSync(filename, 'utf8');
-                compiled = babel.transform(content, {nonStandard: true, retainLines: true});
-                return module._compile(compiled.code, filename);
-            }
-            else {
-                // Instrument
-                content = fs.readFileSync(filename, 'utf8');
-                compiled = babel.transform(content, {nonStandard: true, retainLines: true});
-                var instrumented = instrumenter.instrumentSync(compiled.code, filename);
-                return module._compile(instrumented, filename);
-            }
-        };
-    }
-    else {
-        require.extensions['.jsx'] = function (module, filename) {
+        if (instrument && instrument === 'true' && !/(tests|node_modules)/.test(filename)) {
+            var istanbul = require('istanbul');
+            var coverageVariable = Object.keys(global).filter(
+                function (key) {
+                    return /^\$\$cov_/.test(key);
+                })[0];
+            var instrumenter = new istanbul.Instrumenter({
+                    coverageVariable: coverageVariable
+                });
             var content = fs.readFileSync(filename, 'utf8');
             var compiled = babel.transform(content, {nonStandard: true, retainLines: true});
-            return module._compile(compiled.code, filename);
-        };
-    }
+            var instrumented = instrumenter.instrumentSync(compiled.code, filename);
+
+            return module._compile(instrumented, filename);
+        }
+
+        return module._compile(compiled.code, filename);
+    };
 
     return this;
 }

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -156,7 +156,7 @@ function jsxTranspile(instrument) {
             });
         require.extensions['.jsx'] = function (module, filename) {
             var content = fs.readFileSync(filename, 'utf8');
-            var compiled = babel.transform(content, {nonStandard: true});
+            var compiled = babel.transform(content, {nonStandard: true, retainLines: true});
             var instrumented = instrumenter.instrumentSync(compiled.code, filename);
             return module._compile(instrumented, filename);
         };
@@ -164,7 +164,7 @@ function jsxTranspile(instrument) {
     else {
         require.extensions['.jsx'] = function (module, filename) {
             var content = fs.readFileSync(filename, 'utf8');
-            var compiled = babel.transform(content, {nonStandard: true});
+            var compiled = babel.transform(content, {nonStandard: true, retainLines: true});
             return module._compile(compiled.code, filename);
         };
     }

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -149,7 +149,7 @@ function jsxTranspile(instrument) {
         var content = fs.readFileSync(filename, 'utf8');
         var compiled = babel.transform(content, {nonStandard: true, retainLines: true});
 
-        if (instrument && instrument === 'true' && !/(tests|node_modules)/.test(filename)) {
+        if (instrument && instrument !== 'false' && !/(tests|node_modules)/.test(filename)) {
             var istanbul = require('istanbul');
             var coverageVariable = Object.keys(global).filter(
                 function (key) {

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -145,7 +145,7 @@ function jsxTranspile(instrument) {
     var fs = require('fs');
     var babel = require('babel');
 
-    if (instrument !== undefined && instrument && instrument === 'true') {
+    if (instrument && instrument === 'true') {
         var istanbul = require('istanbul');
         var coverageVariable = Object.keys(global).filter(
             function (key) {
@@ -154,11 +154,23 @@ function jsxTranspile(instrument) {
         var instrumenter = new istanbul.Instrumenter({
                 coverageVariable: coverageVariable
             });
+        var content;
+        var compiled;
+
         require.extensions['.jsx'] = function (module, filename) {
-            var content = fs.readFileSync(filename, 'utf8');
-            var compiled = babel.transform(content, {nonStandard: true, retainLines: true});
-            var instrumented = instrumenter.instrumentSync(compiled.code, filename);
-            return module._compile(instrumented, filename);
+            if (/(tests|node_modules)/.test(filename)) {
+                // No instrument
+                content = fs.readFileSync(filename, 'utf8');
+                compiled = babel.transform(content, {nonStandard: true, retainLines: true});
+                return module._compile(compiled.code, filename);
+            }
+            else {
+                // Instrument
+                content = fs.readFileSync(filename, 'utf8');
+                compiled = babel.transform(content, {nonStandard: true, retainLines: true});
+                var instrumented = instrumenter.instrumentSync(compiled.code, filename);
+                return module._compile(instrumented, filename);
+            }
         };
     }
     else {


### PR DESCRIPTION
@3den 

As per @akshayp's comments in https://github.com/yahoo/jsx-test/pull/13, this PR:

- [x] added [`retainLines`][1] in Babel transformation to avoid wacky code.
- [x] not instrumented files in `test` / `node_modules` folder.

[1]: https://babeljs.io/docs/usage/options/

/cc @akshayp 