### PR TITLE
Istanbul should be a real dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
     "homepage": "https://github.com/yahoo/jsx-test",
     "devDependencies": {
         "babel": "^5.0",
-        "istanbul": "^0.3.15",
         "jenkins-mocha": "^2.2.0",
         "react": "^0.14.0"
     },
     "dependencies": {
+        "istanbul": "^0.3.15",
         "node-jsdom": "^3.1",
         "react-addons-test-utils": "^0.14.1",
         "react-dom": "^0.14.1"


### PR DESCRIPTION
@3den @stanleyhlng 

Since it is required by the helper to get code coverage, it should be a `dependency`. Otherwise, libraries have to include it themselves.
