### PR TITLE
Move from node-jsdom to jsdom

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
 language: node_js
 node_js:
-    - '0.12'
-    - '0.11'
-    - '0.10'
+    - '4'

--- a/index.js
+++ b/index.js
@@ -6,9 +6,9 @@
 
 // Set browser globals, needs to happen before react is required
 // You must require jsxTest before any React stuff
-var jsdom = require('node-jsdom');
-global.document = jsdom.jsdom('<!doctype html><html><body></body></html>');
-global.window = document.parentWindow;
+var jsdom = require('jsdom').jsdom;
+global.document = jsdom('<!doctype html><html><body></body></html>');
+global.window = document.defaultView;
 global.appContainer = document.createElement('section');
 global.navigator = window.navigator;
 global.Event = window.Event;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jsx-test",
-    "version": "1.0.0",
+    "version": "2.0.0",
     "description": "An easy way to test your React Components (`.jsx` files).",
     "main": "index.js",
     "scripts": {
@@ -28,7 +28,7 @@
         "jenkins-mocha": "^2.2.0"
     },
     "dependencies": {
-        "node-jsdom": "^3.1",
+        "jsdom": "^8.1.0",
         "react": "^15.0.0",
         "react-addons-test-utils": "^15.0.0",
         "react-dom": "^15.0.0"


### PR DESCRIPTION
@redonkulus
Moving from node-jsdom to jsdom.
node-jsdom is a fork of jsdom@3.x, originally created because jsdom did not work with node.
Now it does, is more active and node-jsdom is also limiting jsx-test to be used in projects on node 4.x and above. I have also bumped the version to 2.0 since this version of jsdom requires Node.js 4 or newer.